### PR TITLE
Support `should_skip_if`, `incoming_should_skip_if` and `outgoing_should_skip_if`

### DIFF
--- a/lib/json_key_transformer_middleware/incoming_json_formatter.rb
+++ b/lib/json_key_transformer_middleware/incoming_json_formatter.rb
@@ -6,7 +6,7 @@ module JsonKeyTransformerMiddleware
   class IncomingJsonFormatter < Middleware
 
     def call(env)
-      unless should_skip?(env)
+      unless should_skip?(env) || incoming_should_skip?(env)
         object = Oj.load(env['rack.input'].read)
         transformed_object = HashKeyTransformer.send(middleware_config.incoming_strategy, object, middleware_config.incoming_strategy_options)
         result = Oj.dump(transformed_object, mode: :compat)

--- a/lib/json_key_transformer_middleware/incoming_params_formatter.rb
+++ b/lib/json_key_transformer_middleware/incoming_params_formatter.rb
@@ -6,7 +6,7 @@ module JsonKeyTransformerMiddleware
   class IncomingParamsFormatter < Middleware
 
     def call(env)
-      unless should_skip?(env)
+      unless should_skip?(env) || incoming_should_skip?(env)
         parsed_params = Rack::Utils.parse_nested_query(env['QUERY_STRING'])
         transformed_params = HashKeyTransformer.send(middleware_config.incoming_strategy, parsed_params, middleware_config.incoming_strategy_options)
         env['QUERY_STRING'] = Rack::Utils.build_nested_query(transformed_params)

--- a/lib/json_key_transformer_middleware/middleware.rb
+++ b/lib/json_key_transformer_middleware/middleware.rb
@@ -12,6 +12,18 @@ module JsonKeyTransformerMiddleware
       check_skip_paths(env) || check_should_skip_if(env)
     end
 
+    def incoming_should_skip?(env)
+      return false unless middleware_config.should_skip_if.is_a? Proc
+
+      middleware_config.should_skip_if.call(env)
+    end
+
+    def outgoing_should_skip?(env)
+      return false unless middleware_config.should_skip_if.is_a? Proc
+
+      middleware_config.should_skip_if.call(env)
+    end
+
     private
 
     attr_reader :app, :middleware_config

--- a/lib/json_key_transformer_middleware/middleware.rb
+++ b/lib/json_key_transformer_middleware/middleware.rb
@@ -9,6 +9,14 @@ module JsonKeyTransformerMiddleware
     protected
 
     def should_skip?(env)
+      check_skip_paths(env) || check_should_skip_if(env)
+    end
+
+    private
+
+    attr_reader :app, :middleware_config
+
+    def check_skip_paths(env)
       middleware_config.skip_paths.any? do |skip_path|
         case skip_path
         when String
@@ -19,9 +27,11 @@ module JsonKeyTransformerMiddleware
       end
     end
 
-    private
+    def check_should_skip_if(env)
+      return false unless middleware_config.should_skip_if.is_a? Proc
 
-    attr_reader :app, :middleware_config
+      middleware_config.should_skip_if.call(env)
+    end
 
   end
 

--- a/lib/json_key_transformer_middleware/outgoing_json_formatter.rb
+++ b/lib/json_key_transformer_middleware/outgoing_json_formatter.rb
@@ -8,7 +8,7 @@ module JsonKeyTransformerMiddleware
     def call(env)
       status, headers, body = @app.call(env)
 
-      return [status, headers, body] if should_skip?(env)
+      return [status, headers, body] if should_skip?(env) || outgoing_should_skip?(env)
 
       new_body = build_new_body(body)
 

--- a/lib/json_key_transformer_middleware/railtie.rb
+++ b/lib/json_key_transformer_middleware/railtie.rb
@@ -10,6 +10,7 @@ module JsonKeyTransformerMiddleware
     config.json_key_transformer_middleware.outgoing_strategy = :transform_underscore_to_camel
     config.json_key_transformer_middleware.outgoing_strategy_options = ActiveSupport::OrderedOptions.new
     config.json_key_transformer_middleware.skip_paths = []
+    config.json_key_transformer_middleware.should_skip_if = nil
 
     config.app_middleware.insert_after(Rails::Rack::Logger, JsonKeyTransformerMiddleware::IncomingParamsFormatter, config.json_key_transformer_middleware)
     config.app_middleware.insert_after(Rails::Rack::Logger, JsonKeyTransformerMiddleware::IncomingJsonFormatter, config.json_key_transformer_middleware)

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@ The Railtie provides these configuration options:
 * `outgoing_strategy` - default value of `:transform_underscore_to_camel`.
 * `outgoing_strategy_options` - no options set by default.
 * `skip_paths` - skip the transformation if HTTP request path matches. e.g. `[/^\/admin/, '/graphql']`
+* `should_skip_if` - skip the transformation if return true. called with Rack `env`. e.g. `->(env) { env['HTTP_SOME_HEADER'] == 'true' }`
 
 Here is an example Rails initializer which turns on the `outgoing_strategy_options.keep_lead_underscore` option:
 

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,8 @@ The Railtie provides these configuration options:
 * `outgoing_strategy_options` - no options set by default.
 * `skip_paths` - skip the transformation if HTTP request path matches. e.g. `[/^\/admin/, '/graphql']`
 * `should_skip_if` - skip the transformation if return true. called with Rack `env`. e.g. `->(env) { env['HTTP_SOME_HEADER'] == 'true' }`
+* `incoming_should_skip_if` - like `should_skip_if` but only for skipping incoming params / json body
+* `outgoing_should_skip_if` - like `should_skip_if` but only for skipping outgoing json body
 
 Here is an example Rails initializer which turns on the `outgoing_strategy_options.keep_lead_underscore` option:
 


### PR DESCRIPTION
We use [inertiajs](https://inertiajs.com/), which it would send either HTML payload like `<div id='app' page='{component: 'MyPage', props: { foo_bar: 1 }}' />`, or JSON payload like `{ component: 'MyPage', props: { foo_bar: 1 }}` from server. 

In this case, using the [`transformProps`](https://inertiajs.com/transforming-props) to do the snake_case -> camelCase transformation in client-side js is easier. Therefore we would need to skip `JsonKeyTransformerMiddleware::OutgoingJsonFormatter` conditionally like:

```
Rails.application.config.json_key_transformer_middleware.outgoing_should_skip_if = lambda do |env|
  env['HTTP_X_INERTIA'] == 'true'
end
```