### PR TITLE
Check Content-Type ~= application/json by default

### DIFF
--- a/lib/json_key_transformer_middleware/middleware.rb
+++ b/lib/json_key_transformer_middleware/middleware.rb
@@ -9,7 +9,7 @@ module JsonKeyTransformerMiddleware
     protected
 
     def should_skip?(env)
-      check_skip_paths(env) || check_should_skip_if(env)
+      check_skip_paths(env) || check_content_type(env) || check_should_skip_if(env)
     end
 
     def incoming_should_skip?(env)
@@ -37,6 +37,15 @@ module JsonKeyTransformerMiddleware
           skip_path.match? env['PATH_INFO']
         end
       end
+    end
+
+    def check_content_type(env)
+      return false unless middleware_config.check_content_type
+
+      request = Rack::Request.new(env)
+      return false if request.content_type.nil? # Do not skip if Content-Type is unknown
+
+      !%r{application/json}.match?(request.content_type)
     end
 
     def check_should_skip_if(env)

--- a/lib/json_key_transformer_middleware/railtie.rb
+++ b/lib/json_key_transformer_middleware/railtie.rb
@@ -11,6 +11,7 @@ module JsonKeyTransformerMiddleware
     config.json_key_transformer_middleware.outgoing_strategy_options = ActiveSupport::OrderedOptions.new
     config.json_key_transformer_middleware.skip_paths = []
     config.json_key_transformer_middleware.should_skip_if = nil
+    config.json_key_transformer_middleware.check_content_type = true
 
     config.app_middleware.insert_after(Rails::Rack::Logger, JsonKeyTransformerMiddleware::IncomingParamsFormatter, config.json_key_transformer_middleware)
     config.app_middleware.insert_after(Rails::Rack::Logger, JsonKeyTransformerMiddleware::IncomingJsonFormatter, config.json_key_transformer_middleware)

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ The Railtie provides these configuration options:
 * `should_skip_if` - skip the transformation if return true. called with Rack `env`. e.g. `->(env) { env['HTTP_SOME_HEADER'] == 'true' }`
 * `incoming_should_skip_if` - like `should_skip_if` but only for skipping incoming params / json body
 * `outgoing_should_skip_if` - like `should_skip_if` but only for skipping outgoing json body
+* `check_content_type` - skip the transformation unless `Content-Type` contains `application/json` (defaults to `true`)
 
 Here is an example Rails initializer which turns on the `outgoing_strategy_options.keep_lead_underscore` option:
 


### PR DESCRIPTION
If `Content-Type: application/x-www-form-urlencoded` or `Content-Type: multipart/form-data`, skip the transforming logic (at least for now).