### PR TITLE
Fix CONTENT_LENGTH for payload with UTF-8

### DIFF
--- a/lib/json_key_transformer_middleware/incoming_json_formatter.rb
+++ b/lib/json_key_transformer_middleware/incoming_json_formatter.rb
@@ -13,7 +13,7 @@ module JsonKeyTransformerMiddleware
 
         env['rack.input'] = StringIO.new(result)
         # Rails uses this elsewhere to parse 'rack.input', it must be updated to avoid truncation
-        env['CONTENT_LENGTH'] = result.length.to_s
+        env['CONTENT_LENGTH'] = result.bytesize.to_s
       end
 
       @app.call(env)


### PR DESCRIPTION
as title

```
irb(main):001:0> 'abc'.length
=> 3
irb(main):002:0> 'abc'.bytesize
=> 3
irb(main):003:0> '中文字'.length
=> 3
irb(main):004:0> '中文字'.bytesize
=> 9
```