### PR TITLE
incoming_strategy & outgoing_strategy accepts Proc

### DIFF
--- a/lib/json_key_transformer_middleware/incoming_json_formatter.rb
+++ b/lib/json_key_transformer_middleware/incoming_json_formatter.rb
@@ -8,7 +8,7 @@ module JsonKeyTransformerMiddleware
     def call(env)
       unless should_skip?(env) || incoming_should_skip?(env)
         object = Oj.load(env['rack.input'].read)
-        transformed_object = HashKeyTransformer.send(middleware_config.incoming_strategy, object, middleware_config.incoming_strategy_options)
+        transformed_object = transform_incoming(object)
         result = Oj.dump(transformed_object, mode: :compat)
 
         env['rack.input'] = StringIO.new(result)

--- a/lib/json_key_transformer_middleware/incoming_params_formatter.rb
+++ b/lib/json_key_transformer_middleware/incoming_params_formatter.rb
@@ -8,7 +8,7 @@ module JsonKeyTransformerMiddleware
     def call(env)
       unless should_skip?(env) || incoming_should_skip?(env)
         parsed_params = Rack::Utils.parse_nested_query(env['QUERY_STRING'])
-        transformed_params = HashKeyTransformer.send(middleware_config.incoming_strategy, parsed_params, middleware_config.incoming_strategy_options)
+        transformed_params = transform_incoming(parsed_params)
         env['QUERY_STRING'] = Rack::Utils.build_nested_query(transformed_params)
       end
 

--- a/lib/json_key_transformer_middleware/middleware.rb
+++ b/lib/json_key_transformer_middleware/middleware.rb
@@ -54,6 +54,22 @@ module JsonKeyTransformerMiddleware
       middleware_config.should_skip_if.call(env)
     end
 
+    def transform_incoming(object)
+      transform(object, middleware_config.incoming_strategy, middleware_config.incoming_strategy_options)
+    end
+
+    def transform_outgoing(object)
+      transform(object, middleware_config.outgoing_strategy, middleware_config.outgoing_strategy_options)
+    end
+
+    def transform(object, strategy, strategy_options)
+      if strategy.is_a? Proc
+        strategy.call(object)
+      else
+        HashKeyTransformer.send(strategy, object, strategy_options)
+      end
+    end
+
   end
 
 end

--- a/lib/json_key_transformer_middleware/outgoing_json_formatter.rb
+++ b/lib/json_key_transformer_middleware/outgoing_json_formatter.rb
@@ -28,7 +28,7 @@ module JsonKeyTransformerMiddleware
     def transform_outgoing_body_part(body_part)
       begin
         object = Oj.load(body_part)
-        transformed_object = HashKeyTransformer.send(middleware_config.outgoing_strategy, object, middleware_config.outgoing_strategy_options)
+        transformed_object = transform_outgoing(object)
         Oj.dump(transformed_object, mode: :compat)
       rescue
         body_part


### PR DESCRIPTION
<code>[HashKeyTransformer](https://github.com/accelecode/hash_key_transformer)#transform_underscore_to_camel</code> currently convert 'fooBar' to 'foobar'.

For now we just use `String#camelize` instead:
```
Rails.application.config.json_key_transformer_middleware.outgoing_strategy = lambda do |object|
  object.deep_transform_keys! { |key| key.camelize(:lower) }
end
```