### PR TITLE
fix(OutgoingJsonFormatter): do not ignore error from transform_outgoing

### DIFF
--- a/lib/json_key_transformer_middleware/outgoing_json_formatter.rb
+++ b/lib/json_key_transformer_middleware/outgoing_json_formatter.rb
@@ -26,13 +26,16 @@ module JsonKeyTransformerMiddleware
     end
 
     def transform_outgoing_body_part(body_part)
+      object = nil
+
       begin
         object = Oj.load(body_part)
-        transformed_object = transform_outgoing(object)
-        Oj.dump(transformed_object, mode: :compat)
-      rescue
-        body_part
+      rescue Oj::ParseError # ignore HTML, CSV ...etc
+        return body_part
       end
+
+      transformed_object = transform_outgoing(object)
+      Oj.dump(transformed_object, mode: :compat)
     end
 
   end


### PR DESCRIPTION
The `rescue` was only meant to skip non-JSON `body_part` (e.g. `<html>...</html>`). If something when wrong in `transform_outgoing` the error should be raise. This change limits the rescue behavior to only handle `Oj::ParseError` of `Oj.load`.